### PR TITLE
Use fix port and create topics

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 quarkus.kafka-streams.topics=wc-in,wc-out
 quarkus.kafka-streams.application-id=simple-app
 quarkus.kafka-streams.bootstrap-servers=localhost:9092
+quarkus.kafka.devservices.port=9092
+quarkus.kafka.devservices.topic-partitions.wc-in=1
+quarkus.kafka.devservices.topic-partitions.wc-out=1


### PR DESCRIPTION
Hi @open-sudo,

There were 2 issues with quarkus:dev:

- devservice port is random by default
- KafkaStreams will wait for topics in quarkus.kafka-streams.topics to be created, so you need to tell the Kafka DevService to create them

cf https://quarkus.io/guides/kafka-dev-services